### PR TITLE
Add editor config and new uri

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# http://EditorConfig.org
+root=true
+
+[*]
+charset = utf-8
+end_of_line = crlf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/index.html
+++ b/index.html
@@ -95,7 +95,7 @@
             @eswat            dat://95633b6a2ece545004fa92ab37d0390824cd512da0904ad164eaff7c266b7414/
             @misuba           dat://4d61426dea41c9e37784161ef4d8e4f48dd08fb7b9d7991ad3beab8b71a8c048/
             @andreas          dat://fa5c5d7f8877708671d548c4e8c2bb27db7084b1591d8a778fa65e310bccccc0/
-            @flngn          dat://a0db1e591ae5a557453866589dce51acd4e471bc5b22967c4d308298c21bec48/
+            @flngn            dat://a0db1e591ae5a557453866589dce51acd4e471bc5b22967c4d308298c21bec48/
             </div>
         </div>
     </body>

--- a/index.html
+++ b/index.html
@@ -85,6 +85,7 @@
             @lacoiot          dat://b4f41d7a9db109f1e99591d119832a13c2aea51e28c1187b1800121669eaa7ac/
             @esduel           dat://0f4d9d3869e493d8c7adf47fcb23f12ad173137e3726e21b7d9a48bfc70be7bb/
             @xoorath          dat://94a41dca16b5c3596f006e5a20ee54603ceb3758255bb0a0d84f1a94d75de870/
+            @saul             dat://809b8c277bbdaa05d47ade6aab2f10345b9999208f0ff73ac8eff24c0988011e/
             @morniak          dat://0da2f8a9743dde1c6bc20908679d66958056c7902bf6ff8c5650203b8d51bc7d/
             @millenomi        dat://a06dbaea2cc5f76422b82372742e3b7049d47365dc578be1f41f756d32963cca/
             @nsasadb0xn       dat://f7dce614f60295f5f1953e4e66156c931d9c61dc999044f7089da20d4b6a6350/


### PR DESCRIPTION
On my first attempt at adding my URI to the list I found that my text editor wanted to change line-endings from `crlf` to `lf` and so the diff was out-of-whack.

I then decided this was a good opportunity to add an [`.editorconfig`](http://editorconfig.org) file to standardise whitespace defaults.

I also snook in a few indentation fixes for the HTML.

I would be keen to further update the HTML structure to make it a little more semantic in an additional PR should you be interested?