### PR TITLE
change dat link into a href

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@ a list of people and their dat urls
 
 You can view it at the following locations  
 **http:** [https://cblgh.org/rotonde.html](https://cblgh.org/rotonde.html)  
-**dat:** dat://d72c5cebc4b19c3bdbd5e6eae3ccf75ba7a311e73bb87ae29aac02c50174d4da/
+**dat:** [dat://d72c5cebc4b19c3bdbd5e6eae3ccf75ba7a311e73bb87ae29aac02c50174d4da/](dat://d72c5cebc4b19c3bdbd5e6eae3ccf75ba7a311e73bb87ae29aac02c50174d4da/)


### PR DESCRIPTION
This will make it easier for people who have dat:// associated with
their beaker browser installation.